### PR TITLE
Fixed broken Links referring to Fireplane Settings

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,7 +39,7 @@ You can do it in the Settings > FPD menu or using our CLI tool.
 
 In order for the Daemon to talk to the Fiberplane Studio successfully it needs to be successfully authorized. This step will generate a **Daemon API Token** that will be needed later.
 
-1. Go to your Fiberplane [Settings page](https://fiberplane.com/settings).
+1. Go to your Fiberplane **Settings** page.
 2. Click **`+ New`** to register a proxy with a name that identifies the cluster you will install it into (for example, "Production"). This will generate and display a Daemon API Token that the proxy will use to authenticate with the Fiberplane Studio.
 3. Copy the Daemon API Token generated in Step 2 for the next step.
 

--- a/docs/quickstart/Deploy to Docker.md
+++ b/docs/quickstart/Deploy to Docker.md
@@ -12,7 +12,7 @@ slug: deploy-to-docker
 
 In order for the `fpd` to talk to the Fiberplane Studio successfully it needs to be successfully authorized. This step will generate a **`fpd` API Token** that will be needed later.
 
-1. Go to your Fiberplane [Settings page](https://fiberplane.com/settings).
+1. Go to your Fiberplane **Settings** page.
 2. Click **`+ New`** to register a proxy with a name that identifies the cluster you will install it into (for example, "Production"). This will generate and display a `fpd` API Token that the proxy will use to authenticate with the Fiberplane Studio.
 3. Copy the `fpd` API Token generated in Step 2 for the next step.
 

--- a/docs/quickstart/Deploy to Kubernetes.md
+++ b/docs/quickstart/Deploy to Kubernetes.md
@@ -12,7 +12,7 @@ slug: deploy-to-kubernetes
 
 In order for the `fpd` to talk to the Fiberplane Studio successfully it needs to be successfully authorized. This step will generate a **`fpd` API Token** that will be needed later.
 
-1. Go to your Fiberplane [Settings page](https://fiberplane.com/settings).
+1. Go to your Fiberplane **Settings** page).
 2. Click **`+ New`** to register a proxy with a name that identifies the cluster you will install it into (for example, "Production"). This will generate and display a `fpd` API Token that the proxy will use to authenticate with the Fiberplane Studio.
 3. Copy the `fpd` API Token generated in Step 2 for the next step.
 

--- a/docs/quickstart/Run Locally.md
+++ b/docs/quickstart/Run Locally.md
@@ -23,7 +23,7 @@ Choose your architecture and download the files. Keep them in a single folder (s
 
 In order for the `fpd` to talk to the Fiberplane Studio successfully it needs to be successfully authorized. This step will generate a *`fpd` API Token* that will be needed later.
 
-1. Go to your Fiberplane [Settings page](https://fiberplane.com/settings).
+1. Go to your Fiberplane **Settings** page.
 2. Click `+ New` to register an `fpd` with a name that identifies the cluster you will install it into (for example, "Production"). This will generate and display an `fpd` API Token that the proxy will use to authenticate with the Fiberplane Studio.
 3. Copy the `fpd` API Token generated in Step 2 for the next step.
 


### PR DESCRIPTION
I think it is better to highlight Settings page as Settings page is only available only after authentication and it will remain as broken link if we refer to the url in doc.
So, just highlighted Settings in 4 pages where there was broken link of the above.